### PR TITLE
update: JavaScriptサンプルに録音サンプリング周波数の指定機能を追加

### DIFF
--- a/Hrp/javascript/hrp.html
+++ b/Hrp/javascript/hrp.html
@@ -101,6 +101,7 @@ td {font-size: 14px; border: 1px solid #000;}
  <tr class="options" style="display:none;"><td>&nbsp;<font color="silver">認識結果文字エンコーディング</font></td><td><input type="text" class="text" id="resultEncoding" spellcheck="false" tabindex="3"></td></tr>
  <tr><td>&nbsp;APPKEY</td><td><input type="text" class="text" id="serviceAuthorization" spellcheck="false" tabindex="3"></td></tr>
  <tr class="options" style="display:none;"><td>&nbsp;発話区間検出パラメータ情報</td><td><input type="text" class="text" id="voiceDetection" spellcheck="false" tabindex="3"></td></tr>
+ <tr class="options" style="display:none;"><td>&nbsp;録音サンプリング周波数</td><td><input type="text" class="text" id="sampleRate" spellcheck="false" tabindex="3"></td></tr>
  <tr class="options" style="display:none;"><td>&nbsp;連続録音可能時間 (単位: ミリ秒)</td><td><input type="text" class="text" id="maxRecordingTime" spellcheck="false" tabindex="3"></td></tr>
  <tr class="options" style="display:none;"><td>&nbsp;ダウンサンプリング</td><td><input type="checkbox" class="checkbox" id="downSampling" tabindex="3"></td></tr>
  <tr><td>&nbsp;<font color="silver">(音声データ)</font></td><td><div id="audio" class="text" tabindex="4"></div></td></tr>
@@ -245,25 +246,6 @@ td {font-size: 14px; border: 1px solid #000;}
   var recognitionResultText = document.getElementsByClassName("recognitionResultText");
   var recognitionResultInfo = document.getElementsByClassName("recognitionResultInfo");
 
-  // 画面要素の初期化
-  issuerURL.value = "https://acp-api.amivoice.com/issue_service_authorization";
-  serverURL.value = "https://acp-api.amivoice.com/v1/recognize";
-  grammarFileNames[0].value = Hrp.grammarFileNames;
-  profileId.value = Hrp.profileId;
-  profileWords.value = Hrp.profileWords;
-  segmenterProperties.value = Hrp.segmenterProperties;
-  keepFillerToken.value = Hrp.keepFillerToken;
-  resultUpdatedInterval.value = Hrp.resultUpdatedInterval;
-  extension.value = Hrp.extension;
-  authorization.value = Hrp.authorization;
-  codec.value = Hrp.codec;
-  resultType.value = Hrp.resultType;
-  resultEncoding.value = Hrp.resultEncoding;
-  serviceAuthorization.value = Hrp.serviceAuthorization;
-  voiceDetection.value = Hrp.voiceDetection;
-  maxRecordingTime.value = Recorder.maxRecordingTime;
-  downSampling.checked = Recorder.downSampling;
-
   // 音声認識ライブラリのプロパティ要素の設定
   Hrp.serverURLElement = serverURL;
   Hrp.grammarFileNamesElement = grammarFileNames[0];
@@ -299,8 +281,29 @@ td {font-size: 14px; border: 1px solid #000;}
   Hrp.TRACE = TRACE;
 
   // 録音ライブラリのプロパティ要素の設定
+  Recorder.sampleRateElement = sampleRate;
   Recorder.maxRecordingTimeElement = maxRecordingTime;
   Recorder.downSamplingElement = downSampling;
+
+  // 画面要素の初期化
+  issuerURL.value = "https://acp-api.amivoice.com/issue_service_authorization";
+  serverURL.value = "https://acp-api.amivoice.com/v1/recognize";
+  grammarFileNames[0].value = Hrp.grammarFileNames;
+  profileId.value = Hrp.profileId;
+  profileWords.value = Hrp.profileWords;
+  segmenterProperties.value = Hrp.segmenterProperties;
+  keepFillerToken.value = Hrp.keepFillerToken;
+  resultUpdatedInterval.value = Hrp.resultUpdatedInterval;
+  extension.value = Hrp.extension;
+  authorization.value = Hrp.authorization;
+  codec.value = Hrp.codec;
+  resultType.value = Hrp.resultType;
+  resultEncoding.value = Hrp.resultEncoding;
+  serviceAuthorization.value = Hrp.serviceAuthorization;
+  voiceDetection.value = Hrp.voiceDetection;
+  sampleRate.value = Recorder.sampleRate;
+  maxRecordingTime.value = Recorder.maxRecordingTime;
+  downSampling.checked = Recorder.downSampling;
 
   // 音声認識ライブラリ／録音ライブラリのメソッドの画面要素への登録
   sendButton.onclick = function(e) {

--- a/Wrp/javascript/wrp.html
+++ b/Wrp/javascript/wrp.html
@@ -89,6 +89,7 @@ td {font-size: 14px; border: 1px solid #000;}
  <tr class="options" style="display:none;"><td>&nbsp;<font color="silver">音声データ形式</font></td><td><input type="text" class="text" id="codec" spellcheck="false" tabindex="3" readonly></td></tr>
  <tr class="options" style="display:none;"><td>&nbsp;認識結果タイプ</td><td><input type="text" class="text" id="resultType" spellcheck="false" tabindex="3"></td></tr>
  <tr class="options" style="display:none;"><td>&nbsp;無発話許容時間 (単位：ミリ秒)</td><td><input type="text" class="text" id="checkIntervalTime" spellcheck="false" tabindex="3"></td></tr>
+ <tr class="options" style="display:none;"><td>&nbsp;録音サンプリング周波数</td><td><input type="text" class="text" id="sampleRate" spellcheck="false" tabindex="3"></td></tr>
  <tr class="options" style="display:none;"><td>&nbsp;連続録音可能時間 (単位: ミリ秒)</td><td><input type="text" class="text" id="maxRecordingTime" spellcheck="false" tabindex="3"></td></tr>
  <tr class="options" style="display:none;"><td>&nbsp;ダウンサンプリング</td><td><input type="checkbox" class="checkbox" id="downSampling" tabindex="3"></td></tr>
  <tr class="options" style="display:none;"><td>&nbsp;ADPCM 圧縮</td><td><input type="checkbox" class="checkbox" id="adpcmPacking" tabindex="3"></td></tr>
@@ -257,24 +258,6 @@ td {font-size: 14px; border: 1px solid #000;}
   var recognitionResultText = document.getElementsByClassName("recognitionResultText");
   var recognitionResultInfo = document.getElementsByClassName("recognitionResultInfo");
 
-  // 画面要素の初期化
-  issuerURL.value = "https://acp-api.amivoice.com/issue_service_authorization";
-  serverURL.value = "wss://acp-api.amivoice.com/v1/";
-  grammarFileNames[0].value = Wrp.grammarFileNames;
-  profileId.value = Wrp.profileId;
-  profileWords.value = Wrp.profileWords;
-  segmenterProperties.value = Wrp.segmenterProperties;
-  keepFillerToken.value = Wrp.keepFillerToken;
-  resultUpdatedInterval.value = Wrp.resultUpdatedInterval;
-  extension.value = Wrp.extension;
-  authorization.value = Wrp.authorization;
-  codec.value = Wrp.codec;
-  resultType.value = Wrp.resultType;
-  checkIntervalTime.value = Wrp.checkIntervalTime;
-  maxRecordingTime.value = Recorder.maxRecordingTime;
-  downSampling.checked = Recorder.downSampling;
-  adpcmPacking.checked = Recorder.adpcmPacking;
-
   // 音声認識ライブラリのプロパティ要素の設定
   Wrp.serverURLElement = serverURL;
   Wrp.grammarFileNamesElement = grammarFileNames[0];
@@ -314,9 +297,29 @@ td {font-size: 14px; border: 1px solid #000;}
   Wrp.TRACE = TRACE;
 
   // 録音ライブラリのプロパティ要素の設定
+  Recorder.sampleRateElement = sampleRate;
   Recorder.maxRecordingTimeElement = maxRecordingTime;
   Recorder.downSamplingElement = downSampling;
   Recorder.adpcmPackingElement = adpcmPacking;
+
+  // 画面要素の初期化
+  issuerURL.value = "https://acp-api.amivoice.com/issue_service_authorization";
+  serverURL.value = "wss://acp-api.amivoice.com/v1/";
+  grammarFileNames[0].value = Wrp.grammarFileNames;
+  profileId.value = Wrp.profileId;
+  profileWords.value = Wrp.profileWords;
+  segmenterProperties.value = Wrp.segmenterProperties;
+  keepFillerToken.value = Wrp.keepFillerToken;
+  resultUpdatedInterval.value = Wrp.resultUpdatedInterval;
+  extension.value = Wrp.extension;
+  authorization.value = Wrp.authorization;
+  codec.value = Wrp.codec;
+  resultType.value = Wrp.resultType;
+  checkIntervalTime.value = Wrp.checkIntervalTime;
+  sampleRate.value = Recorder.sampleRate;
+  maxRecordingTime.value = Recorder.maxRecordingTime;
+  downSampling.checked = Recorder.downSampling;
+  adpcmPacking.checked = Recorder.adpcmPacking;
 
   // 音声認識ライブラリ／録音ライブラリのメソッドの画面要素への登録
   resumePauseButton.onclick = function() {

--- a/Wrp/javascript/wrp.js
+++ b/Wrp/javascript/wrp.js
@@ -2,7 +2,7 @@ var Wrp = function() {
 	// public オブジェクト
 	var wrp_ = {
 		// public プロパティ
-		version: "Wrp/1.0.05",
+		version: "Wrp/1.0.07",
 		serverURL: "",
 		serverURLElement: undefined,
 		grammarFileNames: "",
@@ -633,7 +633,7 @@ var Wrp = function() {
 		if (wrp_.authorizationElement) wrp_.authorization = wrp_.authorizationElement.value;
 		if (wrp_.codecElement) wrp_.codec = wrp_.codecElement.value;
 		if (wrp_.resultTypeElement) wrp_.resultType = wrp_.resultTypeElement.value;
-		if (wrp_.checkIntervalTimeElement) wrp_.checkIntervalTime = wrp_.checkIntervalTimeElement.value;
+		if (wrp_.checkIntervalTimeElement) wrp_.checkIntervalTime = wrp_.checkIntervalTimeElement.value - 0;
 		var command = "s ";
 		if (wrp_.codec) {
 			command += wrp_.codec;


### PR DESCRIPTION
update: JavaScriptサンプルに録音サンプリング周波数の指定機能を追加
fix: JavaScriptサンプルでステレオミキサーの音が認識できない問題の対応(エコーキャンセルを無効化)
fix: JavaScriptサンプルで録音サンプリング周波数が48Kと44Kのときにダウンサンプリングを無効化すると録音が正常にできない問題の対応