### PR TITLE
fix: connect()呼び出し後、feedDataResume()の前に受信タイムアウトが発生すると、feedDataResume(…

### DIFF
--- a/Hrp/cpp/src/com/amivoice/hrp/Hrp.cpp
+++ b/Hrp/cpp/src/com/amivoice/hrp/Hrp.cpp
@@ -17,7 +17,7 @@ namespace hrp {
 
 #define __STRING(x) #x
 #define _STRING(x) __STRING(x)
-const char* Hrp::VERSION = "Hrp/1.0.03"
+const char* Hrp::VERSION = "Hrp/1.0.05"
 #ifdef _MSC_VER
 	" MSVC/" _STRING(_MSC_VER)
 #endif
@@ -476,7 +476,7 @@ void Hrp::onClose_() {
 void Hrp::onError_(const std::string& cause) {
 	Poco::SynchronizedObject* synchronizedObject = synchronizedObject_();
 	/* synchronized (this) */ { Poco::ScopedLock<Poco::SynchronizedObject> synchronized(*synchronizedObject);
-		if (state_ == 0 || state_ == 5) {
+		if (state_ == 5) {
 			return;
 		}
 		lastMessage_ = "ERROR: caught exception (" + cause + ")";

--- a/Hrp/cs/src/com/amivoice/hrp/Hrp.cs
+++ b/Hrp/cs/src/com/amivoice/hrp/Hrp.cs
@@ -9,17 +9,17 @@ using System.Web;
 #if !UNITY_2018_4_OR_NEWER
 [assembly: AssemblyTitle("Hrp")]
 [assembly: AssemblyProduct("Hrp")]
-[assembly: AssemblyCopyright("Copyright (C) 2019-2021 Advanced Media, Inc.")]
+[assembly: AssemblyCopyright("Copyright (C) 2019-2023 Advanced Media, Inc.")]
 [assembly: ComVisible(false)]
 [assembly: Guid("d605a501-80ec-4f48-a8fb-2a70e627a257")]
-[assembly: AssemblyVersion("1.0.03")]
-[assembly: AssemblyFileVersion("1.0.03")]
+[assembly: AssemblyVersion("1.0.05")]
+[assembly: AssemblyFileVersion("1.0.05")]
 #endif
 
 namespace com.amivoice.hrp {
 
 public abstract class Hrp {
-	private static string VERSION = "Hrp/1.0.03 CLR/" + System.Environment.Version.ToString() + " (" + System.Environment.OSVersion.ToString() + ")";
+	private static string VERSION = "Hrp/1.0.05 CLR/" + System.Environment.Version.ToString() + " (" + System.Environment.OSVersion.ToString() + ")";
 
 	public static string getVersion() {
 		return VERSION;
@@ -498,7 +498,7 @@ public abstract class Hrp {
 
 	protected void onError_(Exception cause) {
 		lock (this) {
-			if (state_ == 0 || state_ == 5) {
+			if (state_ == 5) {
 				return;
 			}
 			lastMessage_ = "ERROR: caught exception (" + cause.Message + ")";

--- a/Hrp/java/src/com/amivoice/hrp/Hrp.java
+++ b/Hrp/java/src/com/amivoice/hrp/Hrp.java
@@ -4,7 +4,7 @@ import java.io.*;
 import java.net.URLEncoder;
 
 public abstract class Hrp {
-	private static final String VERSION = "Hrp/1.0.03 Java/" + System.getProperty("java.version") + " (" + System.getProperty("os.name") + " " + System.getProperty("os.version") + ")";
+	private static final String VERSION = "Hrp/1.0.05 Java/" + System.getProperty("java.version") + " (" + System.getProperty("os.name") + " " + System.getProperty("os.version") + ")";
 
 	public static String getVersion() {
 		return VERSION;
@@ -506,7 +506,7 @@ public abstract class Hrp {
 
 	protected void onError_(Throwable cause) {
 		synchronized (this) {
-			if (state_ == 0 || state_ == 5) {
+			if (state_ == 5) {
 				return;
 			}
 			lastMessage_ = "ERROR: caught exception (" + cause.getMessage() + ")";

--- a/Hrp/php/src/com/amivoice/hrp/Hrp.php
+++ b/Hrp/php/src/com/amivoice/hrp/Hrp.php
@@ -10,7 +10,7 @@ abstract class Hrp {
 
 	public static function getVersion() {
 		if (self::$VERSION === null) {
-			self::$VERSION = "Hrp/1.0.03 PHP/" . phpversion() . " (" . php_uname('s') . " " . php_uname('r') . " " . php_uname('v') . ")";
+			self::$VERSION = "Hrp/1.0.05 PHP/" . phpversion() . " (" . php_uname('s') . " " . php_uname('r') . " " . php_uname('v') . ")";
 		}
 		return self::$VERSION;
 	}
@@ -468,7 +468,7 @@ abstract class Hrp {
 
 	protected function onError_($cause) {
 		/* synchronized ($this) */ {
-			if ($this->state_ === 0 || $this->state_ === 5) {
+			if ($this->state_ === 5) {
 				return;
 			}
 			$this->lastMessage_ = "ERROR: caught exception (" . $cause->getMessage() . ")";

--- a/Hrp/python/src/com/amivoice/hrp/Hrp.py
+++ b/Hrp/python/src/com/amivoice/hrp/Hrp.py
@@ -18,7 +18,7 @@ except:
 		return quote(s, "UTF-8")
 
 class Hrp(object):
-	VERSION = "Hrp/1.0.03 Python/%d.%d.%d (%s)" % (sys.version_info[0], sys.version_info[1], sys.version_info[2], sys.platform)
+	VERSION = "Hrp/1.0.05 Python/%d.%d.%d (%s)" % (sys.version_info[0], sys.version_info[1], sys.version_info[2], sys.platform)
 
 	@staticmethod
 	def getVersion():
@@ -412,7 +412,7 @@ class Hrp(object):
 
 	def onError_(self, cause):
 		with self.condition_:
-			if self.state_ == 0 or self.state_ == 5:
+			if self.state_ == 5:
 				return
 			self.lastMessage_ = "ERROR: caught exception (" + u(str(cause)) + ")"
 			if self.listener_ != None:

--- a/Wrp/cpp/src/com/amivoice/wrp/Wrp.cpp
+++ b/Wrp/cpp/src/com/amivoice/wrp/Wrp.cpp
@@ -16,7 +16,7 @@ namespace wrp {
 
 #define __STRING(x) #x
 #define _STRING(x) __STRING(x)
-const char* Wrp::VERSION = "Wrp/1.0.03"
+const char* Wrp::VERSION = "Wrp/1.0.05"
 #ifdef _MSC_VER
 	" MSVC/" _STRING(_MSC_VER)
 #endif
@@ -434,7 +434,7 @@ void Wrp::onClose_() {
 void Wrp::onError_(const std::string& cause) {
 	Poco::SynchronizedObject* synchronizedObject = synchronizedObject_();
 	/* synchronized (this) */ { Poco::ScopedLock<Poco::SynchronizedObject> synchronized(*synchronizedObject);
-		if (state_ == 0 || state_ == 5) {
+		if (state_ == 5) {
 			return;
 		}
 		lastMessage_ = "ERROR: caught exception (" + cause + ")";

--- a/Wrp/cs/src/com/amivoice/wrp/Wrp.cs
+++ b/Wrp/cs/src/com/amivoice/wrp/Wrp.cs
@@ -8,11 +8,11 @@ using System.Threading;
 #if !UNITY_2018_4_OR_NEWER
 [assembly: AssemblyTitle("Wrp")]
 [assembly: AssemblyProduct("Wrp")]
-[assembly: AssemblyCopyright("Copyright (C) 2019-2021 Advanced Media, Inc.")]
+[assembly: AssemblyCopyright("Copyright (C) 2019-2023 Advanced Media, Inc.")]
 [assembly: ComVisible(false)]
 [assembly: Guid("d605a501-80ec-4f48-a8fb-2a70e627a256")]
-[assembly: AssemblyVersion("1.0.03")]
-[assembly: AssemblyFileVersion("1.0.03")]
+[assembly: AssemblyVersion("1.0.05")]
+[assembly: AssemblyFileVersion("1.0.05")]
 #endif
 
 namespace com.amivoice.wrp {
@@ -445,7 +445,7 @@ public abstract class Wrp {
 
 	protected void onError_(Exception cause) {
 		lock (this) {
-			if (state_ == 0 || state_ == 5) {
+			if (state_ == 5) {
 				return;
 			}
 			lastMessage_ = "ERROR: caught exception (" + cause.Message + ")";

--- a/Wrp/java/src/com/amivoice/wrp/Wrp.java
+++ b/Wrp/java/src/com/amivoice/wrp/Wrp.java
@@ -3,7 +3,7 @@ package com.amivoice.wrp;
 import java.io.*;
 
 public abstract class Wrp {
-	private static final String VERSION = "Wrp/1.0.03 Java/" + System.getProperty("java.version") + " (" + System.getProperty("os.name") + " " + System.getProperty("os.version") + ")";
+	private static final String VERSION = "Wrp/1.0.05 Java/" + System.getProperty("java.version") + " (" + System.getProperty("os.name") + " " + System.getProperty("os.version") + ")";
 
 	public static String getVersion() {
 		return VERSION;
@@ -484,7 +484,7 @@ public abstract class Wrp {
 
 	protected void onError_(Throwable cause) {
 		synchronized (this) {
-			if (state_ == 0 || state_ == 5) {
+			if (state_ == 5) {
 				return;
 			}
 			lastMessage_ = "ERROR: caught exception (" + cause.getMessage() + ")";

--- a/Wrp/php/src/com/amivoice/wrp/Wrp.php
+++ b/Wrp/php/src/com/amivoice/wrp/Wrp.php
@@ -10,7 +10,7 @@ abstract class Wrp {
 
 	public static function getVersion() {
 		if (self::$VERSION === null) {
-			self::$VERSION = "Wrp/1.0.03 PHP/" . phpversion() . " (" . php_uname('s') . " " . php_uname('r') . " " . php_uname('v') . ")";
+			self::$VERSION = "Wrp/1.0.05 PHP/" . phpversion() . " (" . php_uname('s') . " " . php_uname('r') . " " . php_uname('v') . ")";
 		}
 		return self::$VERSION;
 	}
@@ -427,7 +427,7 @@ abstract class Wrp {
 
 	protected function onError_($cause) {
 		/* synchronized ($this) */ {
-			if ($this->state_ === 0 || $this->state_ === 5) {
+			if ($this->state_ === 5) {
 				return;
 			}
 			$this->lastMessage_ = "ERROR: caught exception (" . $cause->getMessage() . ")";

--- a/Wrp/python/src/com/amivoice/wrp/Wrp.py
+++ b/Wrp/python/src/com/amivoice/wrp/Wrp.py
@@ -18,7 +18,7 @@ except:
 		return quote(s, "UTF-8")
 
 class Wrp(object):
-	VERSION = "Wrp/1.0.03 Python/%d.%d.%d (%s)" % (sys.version_info[0], sys.version_info[1], sys.version_info[2], sys.platform)
+	VERSION = "Wrp/1.0.05 Python/%d.%d.%d (%s)" % (sys.version_info[0], sys.version_info[1], sys.version_info[2], sys.platform)
 
 	@staticmethod
 	def getVersion():
@@ -342,7 +342,7 @@ class Wrp(object):
 
 	def onError_(self, cause):
 		with self.condition_:
-			if self.state_ == 0 or self.state_ == 5:
+			if self.state_ == 5:
 				return
 			self.lastMessage_ = "ERROR: caught exception (" + u(str(cause)) + ")"
 			if self.listener_ != None:


### PR DESCRIPTION
fix: connect()呼び出し後、feedDataResume()の前に受信タイムアウトが発生すると、feedDataResume()がロックされてしまう問題の対応